### PR TITLE
fix(removeOffCanvasPaths): Invalid removal when line path starts with relative move

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ package-lock.json
 [._]s[a-rt-v][a-z]
 [._]ss[a-gi-z]
 [._]sw[a-p]
+
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ test/cli/output
 coverage
 .DS_Store
 .vscode
+.idea
 *.log
 package-lock.json
 
@@ -24,5 +25,3 @@ package-lock.json
 [._]s[a-rt-v][a-z]
 [._]ss[a-gi-z]
 [._]sw[a-p]
-
-.idea/

--- a/plugins/_path.js
+++ b/plugins/_path.js
@@ -253,10 +253,18 @@ export const intersects = function (path1, path2) {
 
   // Check intersection of every subpath of the first path with every subpath of the second.
   return hullNest1.some(function (hull1) {
-    if (hull1.list.length < 3) return false;
+    if (hull1.list.length < 3) {
+      // When there are only two points in the convex hull, add the first point to close the polygon.
+      // This can happen when the path is only a line.
+      hull1.list.push(hull1.list[0]);
+    }
 
     return hullNest2.some(function (hull2) {
-      if (hull2.list.length < 3) return false;
+      if (hull2.list.length < 3) {
+        // When there are only two points in the convex hull, add the first point to close the polygon.
+        // This can happen when the path is only a line.
+        hull2.list.push(hull2.list[0]);
+      }
 
       var simplex = [getSupport(hull1, hull2, [1, 0])], // create the initial simplex
         direction = minus(simplex[0]); // set the direction to point towards the origin

--- a/test/plugins/removeOffCanvasPaths.07.svg.txt
+++ b/test/plugins/removeOffCanvasPaths.07.svg.txt
@@ -1,0 +1,13 @@
+Should not throw when path starts with relative move and is within the view box
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+    <path d="m10 5-5 5" stroke="#000"></path>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+    <path d="m10 5-5 5" stroke="#000"/>
+</svg>


### PR DESCRIPTION
replicates the pull into the original repo, but for our fork
see https://github.com/svg/svgo/pull/2086